### PR TITLE
Add tasks to install recording/player packages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-# defaults file for session-recording
+install_session_player: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,12 @@
 ---
-# tasks file for session-recording
+- name: install recording packages
+  package:
+    name: "{{ item }}"
+  loop:
+    - tlog
+    - sssd
+
+- name: install cockpit session player
+  package:
+    name: cockpit-session-recording
+  when: install_session_player


### PR DESCRIPTION
This adds tasks to install the session recording packages.  The
cockpit-based session player can optionally be installed by setting
a variable.