### PR TITLE
Disable CentOS7 CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - docker
 env:
   matrix:
-    - MOLECULE_DISTRO="centos:7"
     - MOLECULE_DISTRO="fedora:28"
     - MOLECULE_DISTRO="fedora:29"
 install:


### PR DESCRIPTION
The tlog package is not curently a part of CentOS7, which causes
the CI tests to fail.  We plan to add tlog to EPEL, but this will
take a bit of time.  For now, we will only run the CI on Fedora 28
and 29.