### PR TITLE
Install latest testInfra version and various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
     - MOLECULE_DISTRO="fedora:29"
 install:
   - pip install molecule docker
+  # workaround until https://github.com/ansible/molecule/issues/1727 is fixed
+  - pip uninstall -y testinfra
+  - pip install testinfra
 script:
   - molecule test
 branches:

--- a/README.md
+++ b/README.md
@@ -6,46 +6,44 @@ This role configures a system for terminal session recording.
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+This role has no required pre-requisites currently.
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
-
-You could specify usage of SSSD which is prefered way of managing recorded users or groups:
+Configure session recording with SSSD, the preferred way of managing recorded users or groups:
 
 - `use_sssd` (default: `True`)
 
-The next variable provides info for SSSD recording scope - `all` / `some` / `none`:
+Configure SSSD recording scope - `all` / `some` / `none`:
 
 - `scope_sssd` (default: `none`)
 
-List of users separated by coma which will be recorded ( e.g. root,user1,q ):
+Comma-separated list of users to be recorded ( e.g. recordeduser, testuser1 ):
 
 - `users_sssd` (default: `""`)
 
-List of users separated by coma which will be recorded ( e.g. users,wheel ):
+Comma-separated list of groups to be recorded ( e.g. recordedgroup, wheel, ):
 
 - `groups_sssd` (default: `""`)
 
-You can choose to install `cockpit-session-recording` package or not:
+Install`the cockpit-session-recording`package(RHEL8 only, currently):
 
 - `install_session_player` (default: `False`)
 
-Next variable specifies output of `tlog-rec-session`. Possible values are: `rsyslog` , `journal`:
+Log writer type(output destination) of tlog-rec-session. Possible values are: `rsyslog` , `journal`:
 
 - `session_recording_output` (default: `journal`)
 
-You can choose to send recorded session to ElasticSearch through rsyslog, therefore next variable provides value hostname of ElasticSearch:
+ElasticSearch hostname, used when session recording is configured to send to ElasticSearch through rsyslog:
 
 - `elastic_host` (default: `localhost`)
 
-There is an option to only restart Cockpit
+Restart the Cockpit service:
 
 - `restart_cockpit` (default: `False`)
 
-And to enable Cockpit to start on boot (this will not start Cockpit right away, but only after reboot)
+Enable Cockpit to start at system boot (this will not start Cockpit right away, only after reboot)
 
 - `enable_cockpit` (default: `False`)
 
@@ -54,11 +52,11 @@ And to enable Cockpit to start on boot (this will not start Cockpit right away, 
 Dependencies
 ------------
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+This role has no dependencies currently.
 
 Example Playbook
 ----------------
-
+~~~
 ---
 - name: SR
   become: yes
@@ -67,11 +65,11 @@ Example Playbook
     - role: session-recording
       vars:
           scope_sssd: "some"
-          users_sssd: "q"
+          users_sssd: "recordeduser"
           install_session_player: True
           restart_cockpit: True
           enable_cockpit: True
-
+~~~
 Testing
 -------
 In-tree tests are provided that use molecule to test the role against docker containers.
@@ -79,7 +77,9 @@ These tests are designed to be used by CI, but they can also be run locally to t
 out while developing.  This is best done by installing molecule in a virtualenv:
 
   `$ virtualenv .venv`
+
   `$ source .venv/bin/activate`
+
   `$ pip install molecule docker`
 
 It is required to run the tests as a user who is authorized to run the 'docker' command
@@ -112,4 +112,6 @@ GPL v3.0
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+- Nathan Kinder @nkinder
+
+- Kirill Glebov @sabbaka

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
     group: root
     mode: 0600
     force: no
-  when: ( use_sssd ) and ( ansible_facts.packages.sssd < "2.1" )
+  when: ( use_sssd ) and ( ansible_facts.packages.sssd[0].version < "2.1" )
   notify: restart sssd
 
 - name: configure sssd session recording config

--- a/templates/etc/tlog/tlog-rec-session.conf.j2
+++ b/templates/etc/tlog/tlog-rec-session.conf.j2
@@ -1,1 +1,82 @@
-{"shell":"/bin/bash","notice":"\nATTENTION! Your session is being recorded!\n\n","latency":10,"payload":2048,"log":{"input":false,"output":true,"window":true},"limit":{"rate":16384,"burst":32768,"action":"pass"},"file":{"path":""},"syslog":{"facility":"authpriv","priority":"info"},"journal":{"priority":"info","augment":true},"writer":"{{ session_recording_writer[session_recording_output] }}"}
+//
+// Tlog-rec-session system-wide configuration. See tlog-rec-session.conf(5) for details.
+// This file uses JSON format with both C and C++ comments allowed.
+//
+{
+    // The path to the shell executable which should be spawned.
+    // "shell" : "/bin/bash",
+
+    // A message which will be printed before starting
+    // recording and the user shell. Can be used to warn
+    // the user that the session is recorded.
+    // "notice" : "\nATTENTION! Your session is being recorded!\n\n",
+
+    // The number of seconds to cache captured data for before logging.
+    // The encoded data which does not reach payload size
+    // stays in memory and is not logged until this number of
+    // seconds elapses.
+    // "latency" : 10,
+
+    // The maximum encoded data (payload) size per message, bytes.
+    // As soon as payload exceeds this number of bytes,
+    // it is formatted into a message and logged.
+    // "payload" : 2048,
+
+    // Logged data set parameters
+    "log": {
+        // If true, user input is logged.
+        // "input" : false,
+
+        // If true, terminal output is logged.
+        // "output" : true,
+
+        // If true, terminal window size changes are logged.
+        // "window" : true
+    },
+
+    // Logging limit parameters
+    "limit": {
+        // The maximum rate messages could be logged at, bytes/sec.
+        // "rate" : 16384,
+
+        // The number of bytes by which logged messages are allowed to exceed
+        // the rate limit momentarily, i.e. "burstiness".
+        // "burst" : 32768,
+
+        // The logging limit action.
+        // If set to "pass" no logging limits will be applied.
+        // If set to "delay", logging will be throttled.
+        // If set to "drop", messages exceeding limits will be dropped.
+        // "action" : "pass"
+    },
+
+    // File writer parameters
+    "file": {
+        // The "file" writer log file path.
+        // "path" : ""
+    },
+
+    // Syslog writer parameters
+    "syslog": {
+        // The syslog facility "syslog" writer should use for messages.
+        // "facility" : "authpriv",
+
+        // The syslog priority "syslog" writer should use for messages.
+        // "priority" : "info"
+    },
+
+    // Journal writer parameters
+    "journal": {
+        // The syslog-style priority "journal" writer should use for messages.
+        // "priority" : "info",
+
+        // If true, the "journal" writer copies the following JSON fields
+        // to Journal fields: user -> TLOG_USER, session -> TLOG_SESSION,
+        // rec -> TLOG_REC, and id -> TLOG_ID.
+        // "augment" : true
+    },
+
+    // The type of "log writer" to use for logging. The writer needs
+    // to be configured using its dedicated parameters.
+    "writer" : "{{ session_recording_writer[session_recording_output] }}"
+}


### PR DESCRIPTION
This PR is a workaround for the CI failure, I tested this successfully locally.
~~~
    ____________________ ERROR collecting tests/test_default.py ____________________
    tests/test_default.py:6: in <module>
        os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
    /home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/testinfra/utils/ansible_runner.py:153: in __init__
        self.cli.options = self.cli.base_parser(
    E   AttributeError: 'PlaybookCLI' object has no attribute 'base_parser'
~~~

The bug is discussed here:
https://github.com/ansible/molecule/issues/1727
https://github.com/philpep/testinfra/issues/401

The fix is in `testInfra` 3.0.0+ versions however the CI virtualenv pip installed `molecule` requires **testinfra==1.19.0** which leads to this bug.

Alternatively, we could wait for the updated `molecule(2.21?)`/`testinfra(3.0.0)` version to be pulled in automatically and CI will be temporarily broken until that happens. If that makes more sense then we can just close this PR.

